### PR TITLE
fix error RN >= 0.6x (removed ListView)

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,11 @@
 
 import listenToKeyboardEvents from './lib/KeyboardAwareHOC'
 import KeyboardAwareScrollView from './lib/KeyboardAwareScrollView'
-import KeyboardAwareListView from './lib/KeyboardAwareListView'
 import KeyboardAwareFlatList from './lib/KeyboardAwareFlatList'
 import KeyboardAwareSectionList from './lib/KeyboardAwareSectionList'
 
 export {
   listenToKeyboardEvents,
-  KeyboardAwareListView,
   KeyboardAwareFlatList,
   KeyboardAwareSectionList,
   KeyboardAwareScrollView


### PR DESCRIPTION
ListView is not more part of React-Native 0.6x:

- removes `KeyboardAwareListView` to fix RN 0.6+ error