### PR TITLE
fix deprecated componentWillReceiveProps

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -238,9 +238,12 @@ function KeyboardAwareHOC(
       })
     }
 
-    componentWillReceiveProps(nextProps: KeyboardAwareHOCProps) {
-      if (nextProps.viewIsInsideTabBar !== this.props.viewIsInsideTabBar) {
-        const keyboardSpace: number = nextProps.viewIsInsideTabBar
+    componentDidUpdate(prevProps: KeyboardAwareHOCProps) {
+      const {viewIsInsideTabBar: prevViewIsInsideTabBar} = prevProps;
+      const {viewIsInsideTabBar: nextViewIsInsideTabBar} = this.props;
+
+      if (prevViewIsInsideTabBar !== nextViewIsInsideTabBar) {
+        const keyboardSpace: number = nextViewIsInsideTabBar
           ? _KAM_DEFAULT_TAB_BAR_HEIGHT
           : 0
         if (this.state.keyboardSpace !== keyboardSpace) {


### PR DESCRIPTION
`componentWillReceiveProps` is deprecated from React.

This will remove one warning in mobile application.